### PR TITLE
Added back missing linked story metadata (on link)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "title": "Shortcut",
   "description": "Link tickets to Shortcut stories so agents can track a story's progress from a ticket",
   "appStoreUrl": "https://www.deskpro.com/product-embed/apps/shortcut",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "scope": "agent",
   "isSingleInstall": true,
   "hasDevMode": true,

--- a/src/pages/Link.tsx
+++ b/src/pages/Link.tsx
@@ -29,7 +29,11 @@ import {
   addExternalUrlToStory,
   searchStories,
 } from "../context/StoreProvider/api";
-import { StorySearchItem } from "../context/StoreProvider/types";
+import {
+  ShortcutStoryAssociationProps,
+  ShortcutStoryAssociationPropsLabel,
+  StorySearchItem
+} from "../context/StoreProvider/types";
 import { useSetAppTitle, useReplyBox } from "../hooks";
 import { isEnableDeskproLabel } from "../utils";
 
@@ -132,7 +136,28 @@ export const Link = () => {
           "linkedShortcutStories",
           context?.data.ticket.id as string
         )
-        .set<{ id: string }>(`${id}`, { id: `${id}` })
+        .set<ShortcutStoryAssociationProps>(`${id}`, {
+          archived: selectedItems[id].archived,
+          id: `${id}`,
+          name: selectedItems[id].name,
+          type: selectedItems[id].type,
+          projectId: selectedItems[id].projectId ? `${selectedItems[id].projectId}` : undefined,
+          projectName: selectedItems[id].projectName,
+          workflowId: `${selectedItems[id].workflowId}`,
+          workflowName: selectedItems[id].workflowName,
+          statusId: selectedItems[id].stateId ? `${selectedItems[id].stateId}` : undefined,
+          statusName: selectedItems[id].stateName,
+          teamId: selectedItems[id].teamId ? `${selectedItems[id].teamId}` : undefined,
+          teamName: selectedItems[id].teamName,
+          iterationId: selectedItems[id].iterationId ? `${selectedItems[id].iterationId}` : undefined,
+          iterationName: selectedItems[id].iterationName,
+          epicId: selectedItems[id].epicId ? `${selectedItems[id].epicId}` : undefined,
+          epicName: selectedItems[id].epicName,
+          labels: selectedItems[id].labels.map<ShortcutStoryAssociationPropsLabel>((label) => ({
+            id: `${label.id}`,
+            name: label.name,
+          })),
+        })
         .then(() => setSelectionState(id, true, "email"))
         .then(() => setSelectionState(id, true, "note"))
     );


### PR DESCRIPTION
Whilst working on https://app.shortcut.com/deskpro/story/108779/filter-lists-on-custom-app-fields-is-very-slow I noticed that the Shortcut story metadata that was set when a story was linked was removed (for unknown reasons). I've added this back in so that SC story metadata is stored when stories are linked to tickets.